### PR TITLE
Markdown - Preparations for iOS13:

### DIFF
--- a/Markdown.podspec
+++ b/Markdown.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Markdown"
-  s.version      = "4.0.0"
+  s.version      = "5.0.0"
   s.summary      = "Markdown parser in swift."
   s.description  = <<-DESC
                    Markdown parser in swift.
@@ -18,11 +18,11 @@ Pod::Spec.new do |s|
   s.author             = { "Johannes Schriewer" => "j.schriewer@anfe.ma" }
   s.social_media_url   = "http://twitter.com/dunkelstern"
 
-  s.ios.deployment_target = "8.4"
-  s.osx.deployment_target = "10.10"
-
-  s.source       = { :git => "git@github.com:anfema/amp-ios-client.git", :tag => "markdown-4.0.0" }
-  s.source_files  = "Markdown/src/*.swift"  
-
-  s.swift_version = '5.0'
+  s.ios.deployment_target = "13.0"
+  s.osx.deployment_target = "11.0"
+  s.swift_version = '5.5'
+  
+  s.source       = { :git => "git@github.com:anfema/amp-ios-client.git", :tag => "markdown-5.0.0" }
+  s.source_files  = "Markdown/src/*.swift"
+  
 end

--- a/markdown/Markdown.xcodeproj/project.pbxproj
+++ b/markdown/Markdown.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5CFA71FC276B82A0003B77B7 /* Markdown.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = Markdown.podspec; path = ../Markdown.podspec; sourceTree = "<group>"; };
 		8F4DD9471BEA5CA3000F917A /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = SOURCE_ROOT; };
 		8F64FD8A1BC51F9500112167 /* Markdown.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Markdown.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F64FD8D1BC51F9500112167 /* Markdown.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Markdown.h; sourceTree = "<group>"; };
@@ -141,6 +142,7 @@
 		8F64FD801BC51F9500112167 = {
 			isa = PBXGroup;
 			children = (
+				5CFA71FC276B82A0003B77B7 /* Markdown.podspec */,
 				8F64FDC21BC5210700112167 /* Source */,
 				8F64FD8C1BC51F9500112167 /* Supporting Files */,
 				8F64FD981BC51F9500112167 /* Tests */,
@@ -350,7 +352,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = anfema;
 				TargetAttributes = {
 					8F64FD891BC51F9500112167 = {
@@ -371,7 +373,7 @@
 					};
 					8FAD5CAA1BF38F7D000C3119 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0910;
+						LastSwiftMigration = 1310;
 					};
 				};
 			};
@@ -583,6 +585,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -608,7 +611,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -641,6 +645,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -660,7 +665,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -682,7 +688,8 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/support/ios/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.markdown;
@@ -704,7 +711,8 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/support/ios/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.markdown;
@@ -749,7 +757,6 @@
 				INFOPLIST_FILE = "$(SRCROOT)/support/osx/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.markdown;
 				PRODUCT_NAME = Markdown;
 				SDKROOT = macosx;
@@ -772,7 +779,6 @@
 				INFOPLIST_FILE = "$(SRCROOT)/support/osx/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.markdown;
 				PRODUCT_NAME = Markdown;
 				SDKROOT = macosx;
@@ -815,12 +821,12 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = iospreview/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.iospreview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -830,12 +836,12 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = iospreview/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.anfema.iospreview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/markdown/Markdown.xcodeproj/xcshareddata/xcschemes/Markdown OSX.xcscheme
+++ b/markdown/Markdown.xcodeproj/xcshareddata/xcschemes/Markdown OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8F64FDA81BC51FB300112167"
+            BuildableName = "Markdown.framework"
+            BlueprintName = "markdown_osx"
+            ReferencedContainer = "container:Markdown.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,17 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8F64FDA81BC51FB300112167"
-            BuildableName = "Markdown.framework"
-            BlueprintName = "markdown_osx"
-            ReferencedContainer = "container:Markdown.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:Markdown.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/markdown/Markdown.xcodeproj/xcshareddata/xcschemes/Markdown iOS.xcscheme
+++ b/markdown/Markdown.xcodeproj/xcshareddata/xcschemes/Markdown iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8F64FD891BC51F9500112167"
+            BuildableName = "Markdown.framework"
+            BlueprintName = "markdown_ios"
+            ReferencedContainer = "container:Markdown.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8F64FD891BC51F9500112167"
-            BuildableName = "Markdown.framework"
-            BlueprintName = "markdown_ios"
-            ReferencedContainer = "container:Markdown.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:Markdown.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/markdown/iospreview/AppDelegate.swift
+++ b/markdown/iospreview/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/markdown/src/markdown.swift
+++ b/markdown/src/markdown.swift
@@ -46,8 +46,8 @@ public enum NodeType {
             return "UnorderedListItem-Node"
         case .orderedList(let nestingDepth):
             return "OrderedList-Node (depth \(nestingDepth))"
-        case .orderedListItem(let index):
-            return "OrderedListItem(\(index))-Node"
+        case .orderedListItem(let index, let nestingDepth):
+            return "OrderedListItem(\(index))-Node (depth \(nestingDepth))"
         case .codeBlock(let language, let nestingDepth):
             return "CodeBlock-Node (lang: \(language), depth \(nestingDepth))"
         case .paragraph(let nestingDepth):


### PR DESCRIPTION
- Updated project settings
- Updated schemes
- Increased minimum deployment target to iOS 13.0 and macos 11.0
- Fixed warning
- Updated podspec
- Converted iospreview code to swift 5