### PR TITLE
Preparations for iOS13:

### DIFF
--- a/ion-client-tests/ios/.swiftlint.yml
+++ b/ion-client-tests/ios/.swiftlint.yml
@@ -19,10 +19,7 @@ disabled_rules: # rule identifiers to exclude from running
 # - trailing_whitespace
 - type_body_length
 # - type_name
-- variable_name_max_length
-- variable_name_min_length
-- variable_name
-- conditional_binding_cascade
+- identifier_name
 - cyclomatic_complexity
 - function_parameter_count
 # - valid_docs

--- a/ion-client-tests/ios/Podfile
+++ b/ion-client-tests/ios/Podfile
@@ -1,18 +1,18 @@
 source 'git@github.com:anfema/anfema-pod-specs.git'
-source 'https://github.com/CocoaPods/Specs'
+source 'https://cdn.cocoapods.org/'
 
 use_frameworks!
-platform :ios, '9.0'
+platform :ios, '13.0'
 
 def shared_pods
     pod 'Alamofire', '~> 4.7'
     pod 'SQLite.swift', '~> 0.12'
     pod 'HashExtensions', '~> 2.0'
-    pod 'DEjson', '~> 4.0'
-    pod 'Markdown', '~> 4.0'
-    pod 'html5tokenizer', '~> 3.0'
-    pod 'Tarpit', '~> 3.0'
-    pod 'anfema-mockingbird', '~> 4.0'
+    pod 'DEjson', '~> 5.0'
+    pod 'Markdown', '~> 5.0'
+    pod 'html5tokenizer', '~> 4.0'
+    pod 'Tarpit', '~> 4.0'
+    pod 'anfema-mockingbird', '~> 5.0'
     pod 'iso-rfc822-date', '~> 1.0'
 end
 
@@ -30,8 +30,9 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
-    if target.name == 'Alamofire'
-      target.build_configurations.each do |config|
+    target.build_configurations.each do |config|
+      config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
+      if target.name == 'Alamofire'
         config.build_settings['SWIFT_VERSION'] = '4.2'
       end
     end

--- a/ion-client-tests/ios/Podfile.lock
+++ b/ion-client-tests/ios/Podfile.lock
@@ -1,28 +1,28 @@
 PODS:
   - Alamofire (4.7.2)
-  - anfema-mockingbird (4.0.0):
+  - anfema-mockingbird (5.0.0):
     - Alamofire (~> 4.2)
-    - DEjson (~> 4.0)
-  - DEjson (4.0.0)
+    - DEjson (~> 5.0)
+  - DEjson (5.0.0)
   - HashExtensions (2.0.0)
-  - html5tokenizer (3.0.0)
+  - html5tokenizer (4.0.0)
   - iso-rfc822-date (1.0.1)
-  - Markdown (4.0.0)
+  - Markdown (5.0.0)
   - SQLite.swift (0.12.0):
     - SQLite.swift/standard (= 0.12.0)
   - SQLite.swift/standard (0.12.0)
-  - Tarpit (3.0.0)
+  - Tarpit (4.0.0)
 
 DEPENDENCIES:
   - Alamofire (~> 4.7)
-  - anfema-mockingbird (~> 4.0)
-  - DEjson (~> 4.0)
+  - anfema-mockingbird (~> 5.0)
+  - DEjson (~> 5.0)
   - HashExtensions (~> 2.0)
-  - html5tokenizer (~> 3.0)
+  - html5tokenizer (~> 4.0)
   - iso-rfc822-date (~> 1.0)
-  - Markdown (~> 4.0)
+  - Markdown (~> 5.0)
   - SQLite.swift (~> 0.12)
-  - Tarpit (~> 3.0)
+  - Tarpit (~> 4.0)
 
 SPEC REPOS:
   "git@github.com:anfema/anfema-pod-specs.git":
@@ -31,7 +31,7 @@ SPEC REPOS:
     - html5tokenizer
     - Markdown
     - Tarpit
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - Alamofire
     - HashExtensions
     - iso-rfc822-date
@@ -39,15 +39,15 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
-  anfema-mockingbird: 441d7b91cd2583a86241a6c667a1e83c92f6ee2d
-  DEjson: 0fd43df22e2265b4c586f722b01d799d52061080
+  anfema-mockingbird: ebb7ea7d9b01a0638c8822ab8cdba25b4eb9a830
+  DEjson: 480faeb146c91123b9721dddb775112f36e8787d
   HashExtensions: f7a7a9c2c318a48a3546eafef32ce3cd210bf2a3
-  html5tokenizer: 166c1b891cac817a6b4469e0ae4eaad7a19181de
+  html5tokenizer: a5fa78faa8ea4603a19580f513f092a5bc5665ab
   iso-rfc822-date: e10feac94cb97cfba1768762786cb772a020343f
-  Markdown: 4534213b99c4f954dc7f420aee0c26749b817e23
+  Markdown: 7549e9ab489475efa70d22d7c0624e50b2a3d716
   SQLite.swift: 7cad9db150a03716336e69469ec9559c85aece5b
-  Tarpit: a46575231c7a0c18b6da0be88dcc95eb22421e10
+  Tarpit: ec174b6a319cd63f1ce6b7331b5aaa68b66f40f2
 
-PODFILE CHECKSUM: 02c9683c4fbd16476e579f4efc9425d65519b4a3
+PODFILE CHECKSUM: 6e30c285364126a20d73a097df6697794695b81c
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.11.2

--- a/ion-client-tests/ios/ion-tests.xcodeproj/project.pbxproj
+++ b/ion-client-tests/ios/ion-tests.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		1E98C8282ACB7CCE10A96175 /* Pods-ion-tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ion-tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ion-tests/Pods-ion-tests.release.xcconfig"; sourceTree = "<group>"; };
 		3C22D82EBE7FE346EEEA7FE6 /* Pods-tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-tests/Pods-tests.release.xcconfig"; sourceTree = "<group>"; };
 		4D107902FA8D80223C9B52FB /* Pods_tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CFA71FE276B92F4003B77B7 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		60186993775AD70A206DE645 /* Pods_ion_client.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ion_client.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		66C573FF63ECE1B60B0B2EA5 /* Pods_ion_tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ion_tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A0EC1301CC7C86D000038EB /* connection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = connection.swift; sourceTree = "<group>"; };
@@ -285,6 +286,7 @@
 		8F78B1DB1BF35689009D4B67 = {
 			isa = PBXGroup;
 			children = (
+				5CFA71FE276B92F4003B77B7 /* .swiftlint.yml */,
 				8F78B2521BF35A42009D4B67 /* ion-client */,
 				8F78B1F91BF35925009D4B67 /* tests */,
 				8F78B1E61BF35689009D4B67 /* test host */,
@@ -607,7 +609,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = "anfema GmbH";
 				TargetAttributes = {
 					8F78B1E31BF35689009D4B67 = {
@@ -754,7 +756,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\n    swiftlint autocorrect\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\n    swiftlint autocorrect\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		86C50D3BEB9F1F50EEDADC37 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -972,6 +974,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -996,7 +999,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1028,6 +1031,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1046,7 +1050,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -1165,6 +1169,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "ion-client/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_PRIVATE_FILE = "";
 				OTHER_LDFLAGS = (
@@ -1210,6 +1215,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "ion-client/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_PRIVATE_FILE = "";
 				OTHER_LDFLAGS = (

--- a/ion-client-tests/ios/ion-tests.xcodeproj/xcshareddata/xcschemes/ion-client.xcscheme
+++ b/ion-client-tests/ios/ion-tests.xcodeproj/xcshareddata/xcschemes/ion-client.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,12 +26,10 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -52,8 +50,6 @@
             ReferencedContainer = "container:ion-tests.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ion-client-tests/ios/ion-tests.xcodeproj/xcshareddata/xcschemes/ion-tests.xcscheme
+++ b/ion-client-tests/ios/ion-tests.xcodeproj/xcshareddata/xcschemes/ion-tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8F78B1E31BF35689009D4B67"
+            BuildableName = "ion-tests.app"
+            BlueprintName = "ion-tests"
+            ReferencedContainer = "container:ion-tests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,17 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8F78B1E31BF35689009D4B67"
-            BuildableName = "ion-tests.app"
-            BlueprintName = "ion-tests"
-            ReferencedContainer = "container:ion-tests.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -72,8 +70,6 @@
             ReferencedContainer = "container:ion-tests.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ion-client-tests/osx/.swiftlint.yml
+++ b/ion-client-tests/osx/.swiftlint.yml
@@ -19,10 +19,7 @@ disabled_rules: # rule identifiers to exclude from running
 # - trailing_whitespace
 - type_body_length
 # - type_name
-- variable_name_max_length
-- variable_name_min_length
-- variable_name
-- conditional_binding_cascade
+- identifier_name
 - cyclomatic_complexity
 - function_parameter_count
 # - valid_docs

--- a/ion-client-tests/osx/Podfile
+++ b/ion-client-tests/osx/Podfile
@@ -1,19 +1,19 @@
 source 'git@github.com:anfema/anfema-pod-specs.git'
-source 'https://github.com/CocoaPods/Specs'
+source 'https://cdn.cocoapods.org/'
 
 use_frameworks!
 
-platform :osx, '10.12'
+platform :osx, '11.0'
 
 def shared_pods
     pod 'Alamofire', '~> 4.7'
     pod 'SQLite.swift', '~> 0.12'
     pod 'HashExtensions', '~> 2.0'
-    pod 'DEjson', '~> 4.0'
-    pod 'Markdown', '~> 4.0'
-    pod 'html5tokenizer', '~> 3.0'
-    pod 'Tarpit', '~> 3.0'
-    pod 'anfema-mockingbird', '~> 4.0'
+    pod 'DEjson', '~> 5.0'
+    pod 'Markdown', '~> 5.0'
+    pod 'html5tokenizer', '~> 4.0'
+    pod 'Tarpit', '~> 4.0'
+    pod 'anfema-mockingbird', '~> 5.0'
     pod 'iso-rfc822-date', '~> 1.0'
 end
 

--- a/ion-client-tests/osx/Podfile.lock
+++ b/ion-client-tests/osx/Podfile.lock
@@ -1,28 +1,28 @@
 PODS:
   - Alamofire (4.7.2)
-  - anfema-mockingbird (4.0.0):
+  - anfema-mockingbird (5.0.0):
     - Alamofire (~> 4.2)
-    - DEjson (~> 4.0)
-  - DEjson (4.0.0)
+    - DEjson (~> 5.0)
+  - DEjson (5.0.0)
   - HashExtensions (2.0.0)
-  - html5tokenizer (3.0.0)
+  - html5tokenizer (4.0.0)
   - iso-rfc822-date (1.0.1)
-  - Markdown (4.0.0)
+  - Markdown (5.0.0)
   - SQLite.swift (0.12.0):
     - SQLite.swift/standard (= 0.12.0)
   - SQLite.swift/standard (0.12.0)
-  - Tarpit (3.0.0)
+  - Tarpit (4.0.0)
 
 DEPENDENCIES:
   - Alamofire (~> 4.7)
-  - anfema-mockingbird (~> 4.0)
-  - DEjson (~> 4.0)
+  - anfema-mockingbird (~> 5.0)
+  - DEjson (~> 5.0)
   - HashExtensions (~> 2.0)
-  - html5tokenizer (~> 3.0)
+  - html5tokenizer (~> 4.0)
   - iso-rfc822-date (~> 1.0)
-  - Markdown (~> 4.0)
+  - Markdown (~> 5.0)
   - SQLite.swift (~> 0.12)
-  - Tarpit (~> 3.0)
+  - Tarpit (~> 4.0)
 
 SPEC REPOS:
   "git@github.com:anfema/anfema-pod-specs.git":
@@ -31,7 +31,7 @@ SPEC REPOS:
     - html5tokenizer
     - Markdown
     - Tarpit
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - Alamofire
     - HashExtensions
     - iso-rfc822-date
@@ -39,15 +39,15 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
-  anfema-mockingbird: 441d7b91cd2583a86241a6c667a1e83c92f6ee2d
-  DEjson: 0fd43df22e2265b4c586f722b01d799d52061080
+  anfema-mockingbird: ebb7ea7d9b01a0638c8822ab8cdba25b4eb9a830
+  DEjson: 480faeb146c91123b9721dddb775112f36e8787d
   HashExtensions: f7a7a9c2c318a48a3546eafef32ce3cd210bf2a3
-  html5tokenizer: 166c1b891cac817a6b4469e0ae4eaad7a19181de
+  html5tokenizer: a5fa78faa8ea4603a19580f513f092a5bc5665ab
   iso-rfc822-date: e10feac94cb97cfba1768762786cb772a020343f
-  Markdown: 4534213b99c4f954dc7f420aee0c26749b817e23
+  Markdown: 7549e9ab489475efa70d22d7c0624e50b2a3d716
   SQLite.swift: 7cad9db150a03716336e69469ec9559c85aece5b
-  Tarpit: a46575231c7a0c18b6da0be88dcc95eb22421e10
+  Tarpit: ec174b6a319cd63f1ce6b7331b5aaa68b66f40f2
 
-PODFILE CHECKSUM: d114cd68d471095003e9a3d183dc4db4a8bafd88
+PODFILE CHECKSUM: 2a9176354c325f4738c8ddf10ef9b36b18885255
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.11.2

--- a/ion-client-tests/osx/ion-tests.xcodeproj/project.pbxproj
+++ b/ion-client-tests/osx/ion-tests.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 /* Begin PBXFileReference section */
 		465EF3BF69444020732BBABF /* Pods-tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-tests/Pods-tests.debug.xcconfig"; sourceTree = "<group>"; };
 		4C96867CF56F1F2F808B8005 /* Pods_tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CFA71FD276B92BD003B77B7 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6A15DFBF1C8F207700932077 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "ion-client/Info.plist"; sourceTree = "<group>"; };
 		6A15DFC01C8F207700932077 /* ion_client.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ion_client.h; path = "ion-client/ion_client.h"; sourceTree = "<group>"; };
 		6AAA551E1CCE004900738B4B /* result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = result.swift; sourceTree = "<group>"; };
@@ -279,6 +280,7 @@
 		8F78B2B21BF36216009D4B67 = {
 			isa = PBXGroup;
 			children = (
+				5CFA71FD276B92BD003B77B7 /* .swiftlint.yml */,
 				8F78B2D91BF3637B009D4B67 /* ion-client */,
 				8F78B2CD1BF36216009D4B67 /* tests */,
 				8F78B2BD1BF36216009D4B67 /* test host */,
@@ -608,7 +610,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = "anfema GmbH";
 				TargetAttributes = {
 					8F78B2BA1BF36216009D4B67 = {
@@ -628,10 +630,9 @@
 			};
 			buildConfigurationList = 8F78B2B61BF36216009D4B67 /* Build configuration list for PBXProject "ion-tests" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -966,6 +967,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -990,7 +992,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -1022,6 +1024,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1040,7 +1043,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -1053,6 +1056,7 @@
 			baseConfigurationReference = DBA5333C6DD7D7779DD819D9 /* Pods-ion-tests.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "ion-tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -1068,6 +1072,7 @@
 			baseConfigurationReference = D9466E1981C25BDBD45B6C86 /* Pods-ion-tests.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "ion-tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";

--- a/ion-client.podspec
+++ b/ion-client.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ion-client"
-  s.version      = "6.2.0"
+  s.version      = "7.0.0"
   s.summary      = "ION-Client for iOS and OS X clients."
   s.description  = <<-DESC
                    ION-Client for iOS and OS X clients
@@ -18,20 +18,20 @@ Pod::Spec.new do |s|
   s.author             = { "Johannes Schriewer" => "j.schriewer@anfe.ma" }
   s.social_media_url   = "http://twitter.com/dunkelstern"
 
-  s.ios.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "13.0"
+  s.osx.deployment_target = "11.0"
 
-  s.source       = { :git => "git@github.com:anfema/ion-client-ios.git", :tag => "6.2.0" }
+  s.source       = { :git => "git@github.com:anfema/ion-client-ios.git", :tag => "7.0.0" }
   s.source_files  = "ion-client/cache/*.swift", "ion-client/communication/*.swift", "ion-client/helper/*.swift", "ion-client/model/**/*.swift", "ion-client/search/*.swift"
 
   s.framework  = "Alamofire", "DEjson", "Markdown", "HashExtensions", "html5tokenizer", "Tarpit"
 
   s.dependency "Alamofire", "~> 4.7"
-  s.dependency "DEjson", "~> 4.0"
-  s.dependency "Markdown", "~> 4.0"
+  s.dependency "DEjson", "~> 5.0"
+  s.dependency "Markdown", "~> 5.0"
   s.dependency "HashExtensions", "~> 2.0"
-  s.dependency "html5tokenizer", "~> 3.0"
-  s.dependency "Tarpit", "~> 3.0"
+  s.dependency "html5tokenizer", "~> 4.0"
+  s.dependency "Tarpit", "~> 4.0"
   s.dependency "iso-rfc822-date", "~> 1.0"
   s.dependency "SQLite.swift", "~> 0.12"
 

--- a/ion-client/Podfile
+++ b/ion-client/Podfile
@@ -1,18 +1,18 @@
 source 'git@github.com:anfema/anfema-pod-specs.git'
-source 'https://github.com/CocoaPods/Specs'
+source 'https://cdn.cocoapods.org/'
 
 use_frameworks!
-platform :osx, '10.12'
+platform :osx, '11.0'
 
 target 'ion_client' do
     pod 'Alamofire', '~> 4.7'
     pod 'SQLite.swift', '~> 0.12'
     pod 'HashExtensions', '~> 2.0'
-    pod 'DEjson', '~> 4.0'
-    pod 'Markdown', '~> 4.0'
-    pod 'html5tokenizer', '~> 3.0'
-    pod 'Tarpit', '~> 3.0'
-    pod 'anfema-mockingbird', '~> 4.0'
+    pod 'DEjson', '~> 5.0'
+    pod 'Markdown', '~> 5.0'
+    pod 'html5tokenizer', '~> 4.0'
+    pod 'Tarpit', '~> 4.0'
+    pod 'anfema-mockingbird', '~> 5.0'
     pod 'iso-rfc822-date', '~> 1.0'
 end
 

--- a/ion-client/Podfile.lock
+++ b/ion-client/Podfile.lock
@@ -1,28 +1,28 @@
 PODS:
   - Alamofire (4.7.2)
-  - anfema-mockingbird (4.0.0):
+  - anfema-mockingbird (5.0.0):
     - Alamofire (~> 4.2)
-    - DEjson (~> 4.0)
-  - DEjson (4.0.0)
+    - DEjson (~> 5.0)
+  - DEjson (5.0.0)
   - HashExtensions (2.0.0)
-  - html5tokenizer (3.0.0)
+  - html5tokenizer (4.0.0)
   - iso-rfc822-date (1.0.1)
-  - Markdown (4.0.0)
+  - Markdown (5.0.0)
   - SQLite.swift (0.12.0):
     - SQLite.swift/standard (= 0.12.0)
   - SQLite.swift/standard (0.12.0)
-  - Tarpit (3.0.0)
+  - Tarpit (4.0.0)
 
 DEPENDENCIES:
   - Alamofire (~> 4.7)
-  - anfema-mockingbird (~> 4.0)
-  - DEjson (~> 4.0)
+  - anfema-mockingbird (~> 5.0)
+  - DEjson (~> 5.0)
   - HashExtensions (~> 2.0)
-  - html5tokenizer (~> 3.0)
+  - html5tokenizer (~> 4.0)
   - iso-rfc822-date (~> 1.0)
-  - Markdown (~> 4.0)
+  - Markdown (~> 5.0)
   - SQLite.swift (~> 0.12)
-  - Tarpit (~> 3.0)
+  - Tarpit (~> 4.0)
 
 SPEC REPOS:
   "git@github.com:anfema/anfema-pod-specs.git":
@@ -31,7 +31,7 @@ SPEC REPOS:
     - html5tokenizer
     - Markdown
     - Tarpit
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - Alamofire
     - HashExtensions
     - iso-rfc822-date
@@ -39,15 +39,15 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
-  anfema-mockingbird: 441d7b91cd2583a86241a6c667a1e83c92f6ee2d
-  DEjson: 0fd43df22e2265b4c586f722b01d799d52061080
+  anfema-mockingbird: ebb7ea7d9b01a0638c8822ab8cdba25b4eb9a830
+  DEjson: 480faeb146c91123b9721dddb775112f36e8787d
   HashExtensions: f7a7a9c2c318a48a3546eafef32ce3cd210bf2a3
-  html5tokenizer: 166c1b891cac817a6b4469e0ae4eaad7a19181de
+  html5tokenizer: a5fa78faa8ea4603a19580f513f092a5bc5665ab
   iso-rfc822-date: e10feac94cb97cfba1768762786cb772a020343f
-  Markdown: 4534213b99c4f954dc7f420aee0c26749b817e23
+  Markdown: 7549e9ab489475efa70d22d7c0624e50b2a3d716
   SQLite.swift: 7cad9db150a03716336e69469ec9559c85aece5b
-  Tarpit: a46575231c7a0c18b6da0be88dcc95eb22421e10
+  Tarpit: ec174b6a319cd63f1ce6b7331b5aaa68b66f40f2
 
-PODFILE CHECKSUM: f756a0dbf53c59001780ac7ec691efc868609092
+PODFILE CHECKSUM: 9bb81d5f7fdff204eb4f39427c0ffd8ae100c1cd
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.11.2

--- a/ion-client/cache/request_cache.swift
+++ b/ion-client/cache/request_cache.swift
@@ -169,7 +169,7 @@ extension IONRequest {
             try data.write(to: fileURL, options: .atomic)
             try ION.config.caching.excludeFileFromBackupIfNecessary(filePath: filePath)
         } catch {
-            //TODO: Handle error
+            // TODO: Handle error
             print("An unexpected error occurred while trying to write file to disk: \(error)")
         }
 

--- a/ion-client/ion-client.xcodeproj/project.pbxproj
+++ b/ion-client/ion-client.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 /* Begin PBXFileReference section */
 		22EDEA0642F1815FE1E26E94 /* Pods-ion_client.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ion_client.release.xcconfig"; path = "Pods/Target Support Files/Pods-ion_client/Pods-ion_client.release.xcconfig"; sourceTree = "<group>"; };
 		3F1D1D2579D05F4EBD155104 /* Pods_ion_client.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ion_client.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CFA71FF276B9418003B77B7 /* ion-client.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = "ion-client.podspec"; path = "../ion-client.podspec"; sourceTree = "<group>"; };
+		5CFA7200276B9418003B77B7 /* readme.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = readme.md; path = ../readme.md; sourceTree = "<group>"; };
 		8F326B0B1CCFB0D30041FC40 /* nsurlcache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = nsurlcache.swift; sourceTree = "<group>"; };
 		8F326B0C1CCFB0D30041FC40 /* request_cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = request_cache.swift; sourceTree = "<group>"; };
 		8F326B0E1CCFB0D30041FC40 /* request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = request.swift; sourceTree = "<group>"; };
@@ -139,6 +141,8 @@
 		8F326AF71CCFB0A70041FC40 = {
 			isa = PBXGroup;
 			children = (
+				5CFA71FF276B9418003B77B7 /* ion-client.podspec */,
+				5CFA7200276B9418003B77B7 /* readme.md */,
 				8F326B0A1CCFB0D30041FC40 /* cache */,
 				8F326B0D1CCFB0D30041FC40 /* communication */,
 				8F326B261CCFB0D30041FC40 /* helper */,
@@ -294,7 +298,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = "anfema GmbH";
 				TargetAttributes = {
 					8F326B4F1CCFB0F30041FC40 = {
@@ -429,6 +433,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -453,7 +458,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -486,6 +491,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -504,7 +510,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";


### PR DESCRIPTION
- Updated project settings
- Updated schemes
- Increased minimum deployment target to iOS 13.0 and macos 11.0
- Updated podspec
- Updated podfiles
- Updated swiftlint configs